### PR TITLE
Add Rust via Emscripten

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ cache:
     - $HOME/.pub-cache
     - $HOME/.phantomjs
     - $HOME/.sysconfcpus
+    - $HOME/.cargo
 branches:
   only:
     - master
@@ -29,8 +30,9 @@ addons:
       - php5-cli
 before_install:
   - |
+    set -e
     if [ ! -d "$HOME/.sysconfcpus/bin" ]; then
-      mkdir "$HOME/.sysconfcpus"
+      mkdir -p "$HOME/.sysconfcpus"
       git clone https://github.com/obmarg/libsysconfcpus.git "$HOME/.sysconfcpus/libsysconfcpus"
       pushd "$HOME/.sysconfcpus/libsysconfcpus"
       ./configure --prefix="$HOME/.sysconfcpus"
@@ -72,6 +74,9 @@ before_install:
   - mkdir -p "$HOME/.phantomjs"
   - if [ ! -f "$HOME/.phantomjs/bin/phantomjs" ]; then curl -o- -sL https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar xjf - -C "$HOME/.phantomjs" --strip-components 1; fi
   - export PATH="$HOME/.phantomjs/bin:$PATH"
+  # Rust
+  - if [ ! -f "$HOME/.cargo/env" ]; then curl https://sh.rustup.rs -sSf | sh -s -- -y; fi
+  - source "$HOME/.cargo/env"
 install:
   - npm install
   # Dart

--- a/bin/test
+++ b/bin/test
@@ -2,17 +2,19 @@
 
 declare -i RESULT=0
 
+root_dir="$(dirname $(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd))"
 npm_bin=$(npm bin)
 
 function runTests {
   echo -e "\n\033[0;33mRunning $1 tests\n\n\t${@:2}\033[0m\n\n"
   time "${@:2}"
   RESULT+=$?
+  cd $root_dir
 }
 
 function runIntegrationTests {
   printf "\n\033[0;33mRunning integration tests for $1\033[0m\n\n"
-  SQL_FORMATTER_LANG="$1" $npm_bin/casperjs test test/integration/index.js
+  SQL_FORMATTER_LANG="$1" $npm_bin/casperjs test "$root_dir/test/integration/index.js"
   RESULT+=$?
 }
 
@@ -33,6 +35,7 @@ if [ "$TRAVIS" == 'true' ]; then
 else
   runTests 'PureScript' $npm_bin/pulp run -I purescript/src --src-path test/purescript -o test/purescript/output -m 'Test.Main'
 fi
+runTests 'Rust' /bin/bash -c 'cd '$root_dir'/rust && cargo test --no-fail-fast --color always'
 runTests 'Scala.js' sbt clean test
 
 # Integration tests
@@ -40,7 +43,7 @@ set -e
 if [ "$TRAVIS" == 'true' ]; then
   # Build Elm and PureScript with 1 CPU to fix performance issues
   sysconfcpus -n 1 npm run dist -- --env.only elm,purescript
-  CLEAN_DIST=false npm run dist -- --env.exclude elm,purescript
+  CLEAN_DIST=false npm run dist -- --env.exclude elm,purescript,rust
 else
   npm run dist
 fi
@@ -57,6 +60,7 @@ runIntegrationTests 'GopherJS'
 runIntegrationTests 'Opal'
 runIntegrationTests 'PHP'
 runIntegrationTests 'PureScript'
+if [ "$TRAVIS" != 'true' ]; then runIntegrationTests 'Rust'; fi
 runIntegrationTests 'ScalaJS'
 
 kill $server_pid

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "purescript-psa": "^0.4.0",
     "purs-loader": "^2.3.0",
     "raw-loader": "^0.5.1",
+    "rust-emscripten-loader": "git+https://github.com/mrdziuban/rust-emscripten-loader.git",
     "sass-loader": "^6.0.1",
     "scalajs-loader": "git+https://github.com/mrdziuban/scalajs-loader.git",
     "style-loader": "^0.13.1",

--- a/rust/.cargo/config
+++ b/rust/.cargo/config
@@ -1,0 +1,4 @@
+[target.asmjs-unknown-emscripten]
+rustflags = [
+  "-Clink-args=-O3 --memory-init-file 0",
+]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1,0 +1,125 @@
+[root]
+name = "sql-formatter"
+version = "0.1.0"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webplatform 0.4.2 (git+https://github.com/mrdziuban/rust-webplatform.git)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "kernel32-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "thread-id"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "webplatform"
+version = "0.4.2"
+source = "git+https://github.com/mrdziuban/rust-webplatform.git#9316fd6ef1b143087ce5e41a22f44387c976f2cb"
+dependencies = [
+ "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum aho-corasick 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0638fd549427caa90c499814196d1b9e3725eb4d15d7339d6de073a680ed0ca2"
+"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
+"checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
+"checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
+"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
+"checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum webplatform 0.4.2 (git+https://github.com/mrdziuban/rust-webplatform.git)" = "<none>"
+"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+authors = ["Matt Dziuban <mrdziuban@gmail.com>"]
+name = "sql-formatter"
+version = "0.1.0"
+
+[dependencies]
+libc = "~0.2"
+regex = "~0.2"
+webplatform = { git = "https://github.com/mrdziuban/rust-webplatform.git" }

--- a/rust/index.js
+++ b/rust/index.js
@@ -1,0 +1,1 @@
+import './src/main';

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,55 @@
+extern crate libc;
+#[cfg(test)] extern crate regex;
+#[macro_use] extern crate webplatform;
+
+mod regex_fns;
+mod sql_formatter;
+
+use std::rc::Rc;
+use webplatform::HtmlNode;
+
+macro_rules! enclose {
+    ( ($( $x:ident ),*) $y:expr ) => {
+        {
+            $(let $x = $x.clone();)*
+            $y
+        }
+    };
+}
+
+fn main() {
+    let document = webplatform::init();
+
+    document.element_query("#main").unwrap().html_set("
+        <div class=\"container\">
+            <div class=\"form-inline mb-3\">
+                <label for=\"sql-spaces\" class=\"h4 mr-3\">Spaces</label>
+                <input id=\"sql-spaces\" class=\"form-control\" type=\"number\" value=\"2\" min=\"0\">
+            </div>
+            <div class=\"form-group\">
+                <label for=\"sql-input\" class=\"d-flex h4 mb-3\">Input</label>
+                <textarea id=\"sql-input\" class=\"form-control code\" placeholder=\"Enter SQL\" rows=\"9\"></textarea>
+            </div>
+            <div class=\"form-group\">
+                <label for=\"sql-output\" class=\"d-flex h4 mb-3\">Output</label>
+                <textarea id=\"sql-output\" class=\"form-control code\" rows=\"20\" readonly></textarea>
+            </div>
+        </div>
+    ");
+
+    let input = Rc::new(document.element_query("#sql-input").unwrap());
+    let output = Rc::new(document.element_query("#sql-output").unwrap());
+    let spaces = Rc::new(document.element_query("#sql-spaces").unwrap());
+
+    input.on("input", enclose! { (input, output, spaces) move |_| { update_output(&input, &output, &spaces) } });
+    spaces.on("input", enclose! { (input, output, spaces) move |_| { update_output(&input, &output, &spaces) } });
+
+    output.on("click", enclose! { (output) move |_| output.call("select") });
+    output.on("focus", enclose! { (output) move |_| output.call("select") });
+
+    webplatform::spin();
+}
+
+fn update_output(input: &Rc<HtmlNode>, output: &Rc<HtmlNode>, spaces: &Rc<HtmlNode>) {
+    output.prop_set_str("value", &sql_formatter::format(input.prop_get_str("value"), spaces.prop_get_i32("value")));
+}

--- a/rust/src/regex_fns.rs
+++ b/rust/src/regex_fns.rs
@@ -1,0 +1,36 @@
+#[cfg(test)]
+use regex::Regex;
+
+use libc;
+use std::ffi::{CString, CStr};
+use std::str;
+use webplatform::Interop;
+
+// These functions are kind of hacky, but using the regex crate
+// makes the compiled js file go from 2.1M to 15M
+pub fn regex_replace(subject: &str, pattern: &str, flags: &str, replacement: &str) -> String {
+    #[cfg(not(test))]
+    {
+        let replaced = js! { (subject, pattern, flags, replacement) b"\
+            var str = UTF8ToString($0).replace(new RegExp(UTF8ToString($1), UTF8ToString($2)), UTF8ToString($3));\
+            return allocate(intArrayFromString(str), 'i8', ALLOC_STACK);\
+        \0" };
+        unsafe {
+            str::from_utf8(CStr::from_ptr(replaced as *const libc::c_char).to_bytes()).unwrap().to_owned()
+        }
+    }
+    #[cfg(test)]
+    String::from(Regex::new(pattern).unwrap().replace_all(subject, replacement))
+}
+
+pub fn regex_match(subject: &str, pattern: &str, flags: &str) -> bool {
+    #[cfg(not(test))]
+    {
+        let matched = js! { (subject, pattern, flags) b"\
+            return new RegExp(UTF8ToString($1), UTF8ToString($2)).test(UTF8ToString($0));\
+        \0" };
+        matched == 1
+    }
+    #[cfg(test)]
+    Regex::new(pattern).unwrap().is_match(subject)
+}

--- a/rust/src/sql_formatter.rs
+++ b/rust/src/sql_formatter.rs
@@ -1,0 +1,312 @@
+use regex_fns::{regex_match, regex_replace};
+use std::iter;
+
+const SEP: &'static str = "~::~";
+
+#[derive(Clone)]
+struct T {
+    stri: String,
+    shift_arr: Vec<String>,
+    tab: String,
+    arr: Vec<String>,
+    parens_level: usize,
+    deep: usize,
+}
+
+pub fn format(sql: String, num_spaces: i32) -> String {
+    let tab: String = iter::repeat(" ").take(num_spaces as usize).collect();
+    let split_by_quotes = regex_replace(&sql.replace("'", &format!("{}'", SEP)), r"\s+", "g", " ");
+    let split_by_quotes: Vec<&str> = split_by_quotes.split(SEP).collect();
+    let mut acc = T {
+        stri: String::from(""),
+        shift_arr: create_shift_arr(&tab),
+        tab: tab.clone(),
+        arr: gen_array(split_by_quotes, &tab),
+        parens_level: 0,
+        deep: 0,
+    };
+
+    for (i, original_el) in acc.clone().arr.iter().enumerate() {
+        let parens_level = subquery_level(original_el, &acc.parens_level) as usize;
+        let mut arr = acc.arr.to_vec();
+        if regex_match(&original_el, r"SELECT|SET", "") {
+            arr[i] = regex_replace(&original_el, r",\s+", "g", &format!(",\n{}{}", acc.tab, acc.tab));
+        }
+        let (stri, deep) = update_str(&arr[i], &parens_level, &acc);
+
+        acc = T {
+            stri: stri,
+            shift_arr: acc.shift_arr,
+            tab: acc.tab,
+            arr: arr,
+            parens_level: parens_level,
+            deep: deep,
+        };
+    }
+
+    let out = regex_replace(&acc.stri, r"\s+\n", "g", "\n");
+    String::from(regex_replace(&out, r"\n+", "g", "\n").trim())
+}
+
+fn update_str(el: &str, parens_level: &usize, acc: &T) -> (String, usize) {
+    if regex_match(el, r"\(\s*SELECT", "") {
+        (format!("{}{}{}", acc.stri, acc.shift_arr[acc.deep + 1], el), acc.deep + 1)
+    } else {
+        let stri = if el.contains("'") { format!("{}{}", acc.stri, el) } else { format!("{}{}{}", acc.stri, acc.shift_arr[acc.deep], el) };
+        let deep = if *parens_level < 1 && acc.deep != 0 { acc.deep - 1 } else { acc.deep };
+        (stri, deep)
+    }
+}
+
+fn create_shift_arr(tab: &str) -> Vec<String> {
+    let mut v = vec![];
+    for i in 0..100 {
+        v.push(format!("\n{}", iter::repeat(tab).take(i).collect::<String>()));
+    }
+    v
+}
+
+fn gen_array(split_by_quotes: Vec<&str>, tab: &str) -> Vec<String> {
+    let mut v: Vec<String> = vec![];
+    for (i, el) in split_by_quotes.iter().enumerate() {
+        v.append(&mut split_if_even(i, *el, tab));
+    }
+    v
+}
+
+fn subquery_level(stri: &str, parens_level: &usize) -> isize {
+    *parens_level as isize - (String::from(stri).replace("(", "").len() as isize - String::from(stri).replace(")", "").len() as isize)
+}
+
+#[cfg(not(test))]
+fn all_replacements<'a>(tab: &str) -> Vec<(&'a str, String)> {
+    vec![
+        (r" AND ",              format!("{}{}AND ", SEP, tab)),
+        (r" BETWEEN ",          format!("{}{}BETWEEN ", SEP, tab)),
+        (r" CASE ",             format!("{}{}CASE ", SEP, tab)),
+        (r" ELSE ",             format!("{}{}ELSE ", SEP, tab)),
+        (r" END ",              format!("{}{}END ", SEP, tab)),
+        (r" FROM ",             format!("{}FROM ", SEP)),
+        (r" GROUP\s+BY ",       format!("{}GROUP BY ", SEP)),
+        (r" HAVING ",           format!("{}HAVING ", SEP)),
+        (r" IN ",               String::from(" IN ")),
+        (r" JOIN ",             format!("{}JOIN ", SEP)),
+        (r" CROSS(~::~)+JOIN ", format!("{}CROSS JOIN ", SEP)),
+        (r" INNER(~::~)+JOIN ", format!("{}INNER JOIN ", SEP)),
+        (r" LEFT(~::~)+JOIN ",  format!("{}LEFT JOIN ", SEP)),
+        (r" RIGHT(~::~)+JOIN ", format!("{}RIGHT JOIN ", SEP)),
+        (r" ON ",               format!("{}{}ON ", SEP, tab)),
+        (r" OR ",               format!("{}{}OR ", SEP, tab)),
+        (r" ORDER\s+BY ",       format!("{}ORDER BY ", SEP)),
+        (r" OVER ",             format!("{}{}OVER ", SEP, tab)),
+        (r"\(\s*SELECT ",       format!("{}(SELECT ", SEP)),
+        (r"\)\s*SELECT ",       format!("){}SELECT ", SEP)),
+        (r" THEN ",             format!(" THEN{}{}", SEP, tab)),
+        (r" UNION ",            format!("{}UNION{}", SEP, SEP)),
+        (r" USING ",            format!("{}USING ", SEP)),
+        (r" WHEN ",             format!("{}{}WHEN ", SEP, tab)),
+        (r" WHERE ",            format!("{}WHERE ", SEP)),
+        (r" WITH ",             format!("{}WITH ", SEP)),
+        (r" SET ",              format!("{}SET ", SEP)),
+        (r" ALL ",              String::from(" ALL ")),
+        (r" AS ",               String::from(" AS ")),
+        (r" ASC ",              String::from(" ASC ")),
+        (r" DESC ",             String::from(" DESC ")),
+        (r" DISTINCT ",         String::from(" DISTINCT ")),
+        (r" EXISTS ",           String::from(" EXISTS ")),
+        (r" NOT ",              String::from(" NOT ")),
+        (r" NULL ",             String::from(" NULL ")),
+        (r" LIKE ",             String::from(" LIKE ")),
+        (r"\s*SELECT ",         String::from("SELECT ")),
+        (r"\s*UPDATE ",         String::from("UPDATE ")),
+        (r"\s*DELETE ",         String::from("DELETE ")),
+        (r"(~::~)+",            String::from(SEP)),
+    ]
+}
+
+#[cfg(test)]
+fn all_replacements<'a>(tab: &str) -> Vec<(&'a str, String)> {
+    vec![
+        (r"(?i) AND ",              format!("{}{}AND ", SEP, tab)),
+        (r"(?i) BETWEEN ",          format!("{}{}BETWEEN ", SEP, tab)),
+        (r"(?i) CASE ",             format!("{}{}CASE ", SEP, tab)),
+        (r"(?i) ELSE ",             format!("{}{}ELSE ", SEP, tab)),
+        (r"(?i) END ",              format!("{}{}END ", SEP, tab)),
+        (r"(?i) FROM ",             format!("{}FROM ", SEP)),
+        (r"(?i) GROUP\s+BY ",       format!("{}GROUP BY ", SEP)),
+        (r"(?i) HAVING ",           format!("{}HAVING ", SEP)),
+        (r"(?i) IN ",               String::from(" IN ")),
+        (r"(?i) JOIN ",             format!("{}JOIN ", SEP)),
+        (r"(?i) CROSS(~::~)+JOIN ", format!("{}CROSS JOIN ", SEP)),
+        (r"(?i) INNER(~::~)+JOIN ", format!("{}INNER JOIN ", SEP)),
+        (r"(?i) LEFT(~::~)+JOIN ",  format!("{}LEFT JOIN ", SEP)),
+        (r"(?i) RIGHT(~::~)+JOIN ", format!("{}RIGHT JOIN ", SEP)),
+        (r"(?i) ON ",               format!("{}{}ON ", SEP, tab)),
+        (r"(?i) OR ",               format!("{}{}OR ", SEP, tab)),
+        (r"(?i) ORDER\s+BY ",       format!("{}ORDER BY ", SEP)),
+        (r"(?i) OVER ",             format!("{}{}OVER ", SEP, tab)),
+        (r"(?i)\(\s*SELECT ",       format!("{}(SELECT ", SEP)),
+        (r"(?i)\)\s*SELECT ",       format!("){}SELECT ", SEP)),
+        (r"(?i) THEN ",             format!(" THEN{}{}", SEP, tab)),
+        (r"(?i) UNION ",            format!("{}UNION{}", SEP, SEP)),
+        (r"(?i) USING ",            format!("{}USING ", SEP)),
+        (r"(?i) WHEN ",             format!("{}{}WHEN ", SEP, tab)),
+        (r"(?i) WHERE ",            format!("{}WHERE ", SEP)),
+        (r"(?i) WITH ",             format!("{}WITH ", SEP)),
+        (r"(?i) SET ",              format!("{}SET ", SEP)),
+        (r"(?i) ALL ",              String::from(" ALL ")),
+        (r"(?i) AS ",               String::from(" AS ")),
+        (r"(?i) ASC ",              String::from(" ASC ")),
+        (r"(?i) DESC ",             String::from(" DESC ")),
+        (r"(?i) DISTINCT ",         String::from(" DISTINCT ")),
+        (r"(?i) EXISTS ",           String::from(" EXISTS ")),
+        (r"(?i) NOT ",              String::from(" NOT ")),
+        (r"(?i) NULL ",             String::from(" NULL ")),
+        (r"(?i) LIKE ",             String::from(" LIKE ")),
+        (r"(?i)\s*SELECT ",         String::from("SELECT ")),
+        (r"(?i)\s*UPDATE ",         String::from("UPDATE ")),
+        (r"(?i)\s*DELETE ",         String::from("DELETE ")),
+        (r"(?i)(~::~)+",            String::from(SEP)),
+    ]
+}
+
+fn split_sql(stri: &str, tab: &str) -> Vec<String> {
+    let mut s = String::from(stri);
+    for r in all_replacements(tab) {
+        s = regex_replace(&s, &r.0, "gi", &r.1);
+    }
+    String::from(s).split(SEP).map(String::from).collect()
+}
+
+fn split_if_even(i: usize, stri: &str, tab: &str) -> Vec<String> {
+    if i % 2 == 0 { split_sql(stri, tab) } else { vec![String::from(stri)] }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format;
+
+    macro_rules! test_formatting {
+        ($($name:ident: $value:expr,)*) => {
+        $(
+            #[test]
+            fn $name() {
+                let (input, expected, num_spaces) = $value;
+                assert_eq!(expected, format(String::from(input), num_spaces));
+            }
+        )*
+        }
+    }
+
+    test_formatting! {
+        // Tabbed keywords
+        formatting_of_and: ("foo AND bar", "foo\n  AND bar", 2),
+        formatting_of_between: ("foo BETWEEN bar", "foo\n  BETWEEN bar", 2),
+        formatting_of_case: ("foo CASE bar", "foo\n  CASE bar", 2),
+        formatting_of_else: ("foo ELSE bar", "foo\n  ELSE bar", 2),
+        formatting_of_end: ("foo END bar", "foo\n  END bar", 2),
+        formatting_of_on: ("foo ON bar", "foo\n  ON bar", 2),
+        formatting_of_or: ("foo OR bar", "foo\n  OR bar", 2),
+        formatting_of_over: ("foo OVER bar", "foo\n  OVER bar", 2),
+        formatting_of_when: ("foo WHEN bar", "foo\n  WHEN bar", 2),
+
+        // Untabbed keywords
+        formatting_of_from: ("foo FROM bar", "foo\nFROM bar", 2),
+        formatting_of_group_by: ("foo GROUP BY bar", "foo\nGROUP BY bar", 2),
+        formatting_of_having: ("foo HAVING bar", "foo\nHAVING bar", 2),
+        formatting_of_join: ("foo JOIN bar", "foo\nJOIN bar", 2),
+        formatting_of_cross_join: ("foo CROSS JOIN bar", "foo\nCROSS JOIN bar", 2),
+        formatting_of_inner_join: ("foo INNER JOIN bar", "foo\nINNER JOIN bar", 2),
+        formatting_of_left_join: ("foo LEFT JOIN bar", "foo\nLEFT JOIN bar", 2),
+        formatting_of_right_join: ("foo RIGHT JOIN bar", "foo\nRIGHT JOIN bar", 2),
+        formatting_of_order_by: ("foo ORDER BY bar", "foo\nORDER BY bar", 2),
+        formatting_of_where: ("foo WHERE bar", "foo\nWHERE bar", 2),
+        formatting_of_with: ("foo WITH bar", "foo\nWITH bar", 2),
+        formatting_of_set: ("foo SET bar", "foo\nSET bar", 2),
+
+        // Unchanged keywords
+        formatting_of_in: ("foo IN bar", "foo IN bar", 2),
+        formatting_of_all: ("foo ALL bar", "foo ALL bar", 2),
+        formatting_of_as: ("foo AS bar", "foo AS bar", 2),
+        formatting_of_asc: ("foo ASC bar", "foo ASC bar", 2),
+        formatting_of_desc: ("foo DESC bar", "foo DESC bar", 2),
+        formatting_of_distinct: ("foo DISTINCT bar", "foo DISTINCT bar", 2),
+        formatting_of_exists: ("foo EXISTS bar", "foo EXISTS bar", 2),
+        formatting_of_not: ("foo NOT bar", "foo NOT bar", 2),
+        formatting_of_null: ("foo NULL bar", "foo NULL bar", 2),
+        formatting_of_like: ("foo LIKE bar", "foo LIKE bar", 2),
+
+        // SELECTs
+        formatting_of_select_1: ("SELECT foo bar", "SELECT foo bar", 2),
+        formatting_of_select_2: (" SELECT foo bar", "SELECT foo bar", 2),
+        formatting_of_select_3: ("foo (SELECT bar", "foo\n  (SELECT bar", 2),
+        formatting_of_select_4: ("foo ( SELECT bar", "foo\n  (SELECT bar", 2),
+        formatting_of_select_5: ("foo) SELECT bar", "foo)\nSELECT bar", 2),
+        formatting_of_select_6: ("foo)SELECT bar", "foo)\nSELECT bar", 2),
+
+        // UPDATEs
+        formatting_of_update_1: ("UPDATE foo bar", "UPDATE foo bar", 2),
+        formatting_of_update_2: (" UPDATE foo bar", "UPDATE foo bar", 2),
+
+        // DELETEs
+        formatting_of_delete_1: ("DELETE foo bar", "DELETE foo bar", 2),
+        formatting_of_delete_2: (" DELETE foo bar", "DELETE foo bar", 2),
+
+        // Special case keywords
+        formatting_of_then:  ("foo THEN bar", "foo THEN\n  bar", 2),
+        formatting_of_union: ("foo UNION bar", "foo\nUNION\nbar", 2),
+        formatting_of_using: ("foo USING bar", "foo\nUSING bar", 2),
+
+        // Nested queries
+        test_single_nested_query: ("SELECT foo FROM (SELECT bar FROM baz)", "SELECT foo\nFROM\n  (SELECT bar\n  FROM baz)", 2),
+        test_multiple_nested_queries: ("SELECT foo FROM (SELECT bar FROM (SELECT baz FROM quux))", "SELECT foo\nFROM\n  (SELECT bar\n  FROM\n    (SELECT baz\n    FROM quux))", 2),
+
+        // Case transformations
+        upcasing_of_and: (" and ", "AND", 2),
+        upcasing_of_between: (" between ", "BETWEEN", 2),
+        upcasing_of_case: (" case ", "CASE", 2),
+        upcasing_of_else: (" else ", "ELSE", 2),
+        upcasing_of_end: (" end ", "END", 2),
+        upcasing_of_on: (" on ", "ON", 2),
+        upcasing_of_or: (" or ", "OR", 2),
+        upcasing_of_over: (" over ", "OVER", 2),
+        upcasing_of_when: (" when ", "WHEN", 2),
+        upcasing_of_from: (" from ", "FROM", 2),
+        upcasing_of_group_by: (" GROUP by ", "GROUP BY", 2),
+        upcasing_of_having: (" having ", "HAVING", 2),
+        upcasing_of_join: (" join ", "JOIN", 2),
+        upcasing_of_cross_join: (" cross join ", "CROSS JOIN", 2),
+        upcasing_of_inner_join: (" inner join ", "INNER JOIN", 2),
+        upcasing_of_left_join: (" left join ", "LEFT JOIN", 2),
+        upcasing_of_right_join: (" right join ", "RIGHT JOIN", 2),
+        upcasing_of_order_by: (" order by ", "ORDER BY", 2),
+        upcasing_of_where: (" where ", "WHERE", 2),
+        upcasing_of_with: (" with ", "WITH", 2),
+        upcasing_of_set: (" set ", "SET", 2),
+        upcasing_of_in: (" in ", "IN", 2),
+        upcasing_of_all: (" all ", "ALL", 2),
+        upcasing_of_as: (" as ", "AS", 2),
+        upcasing_of_asc: (" asc ", "ASC", 2),
+        upcasing_of_desc: (" desc ", "DESC", 2),
+        upcasing_of_distinct: (" distinct ", "DISTINCT", 2),
+        upcasing_of_exists: (" exists ", "EXISTS", 2),
+        upcasing_of_not: (" not ", "NOT", 2),
+        upcasing_of_null: (" null ", "NULL", 2),
+        upcasing_of_like: (" like ", "LIKE", 2),
+        upcasing_of_select: (" select ", "SELECT", 2),
+        upcasing_of_update: (" update ", "UPDATE", 2),
+        upcasing_of_then: (" then ", "THEN", 2),
+        upcasing_of_union: (" union ", "UNION", 2),
+        upcasing_of_using: (" using ", "USING", 2),
+
+        // Full queries
+        formatting_of_full_select: ("SELECT a.b, c.d FROM a JOIN b on a.b = c.d WHERE a.b = 1 AND c.d = 1", "SELECT a.b,\n    c.d\nFROM a\nJOIN b\n  ON a.b = c.d\nWHERE a.b = 1\n  AND c.d = 1", 2),
+        formatting_of_full_update: ("UPDATE a SET a.b = 1, a.c = 2 WHERE a.d = 3", "UPDATE a\nSET a.b = 1,\n    a.c = 2\nWHERE a.d = 3", 2),
+        formatting_of_full_delete: ("DELETE FROM a WHERE a.b = 1 AND a.c = 2", "DELETE\nFROM a\nWHERE a.b = 1\n  AND a.c = 2", 2),
+
+        // Full queries with 4 spaces
+        formatting_of_full_select_with_4_spaces: ("SELECT a.b, c.d FROM a JOIN b on a.b = c.d WHERE a.b = 1 AND c.d = 1", "SELECT a.b,\n        c.d\nFROM a\nJOIN b\n    ON a.b = c.d\nWHERE a.b = 1\n    AND c.d = 1", 4),
+        formatting_of_full_update_with_4_spaces: ("UPDATE a SET a.b = 1, a.c = 2 WHERE a.d = 3", "UPDATE a\nSET a.b = 1,\n        a.c = 2\nWHERE a.d = 3", 4),
+        formatting_of_full_delete_with_4_spaces: ("DELETE FROM a WHERE a.b = 1 AND a.c = 2", "DELETE\nFROM a\nWHERE a.b = 1\n    AND a.c = 2", 4),
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,10 @@ const _languages = {
     name: 'PureScript',
     link: 'http://www.purescript.org/'
   },
+  rust: {
+    name: 'Rust',
+    link: 'https://users.rust-lang.org/t/compiling-to-the-web-with-rust-and-emscripten/7627'
+  },
   scalajs: {
     name: 'Scala.js',
     link: 'http://www.scala-js.org/'
@@ -105,6 +109,7 @@ module.exports = (env) => {
           }
         },
         { test: /\.rb$/, loader: 'opal-loader' },
+        { test: /\.rs$/, loader: 'rust-emscripten-loader', query: { release: prod } },
         { test: /\.scala$/, loader: 'scalajs-loader' },
         {
           test: /\.scss$/,
@@ -125,7 +130,7 @@ module.exports = (env) => {
         template: path.join(__dirname, 'index.ejs')
       })
     ],
-    resolve: { extensions: ['.js', '.dart', '.ejs', '.elm', '.exjs', '.go', '.php', '.purs', '.rb', '.scala', '.scss'] }
+    resolve: { extensions: ['.js', '.dart', '.ejs', '.elm', '.exjs', '.go', '.php', '.purs', '.rb', '.rs', '.scala', '.scss'] }
   };
 
   return Object.defineProperty(merge(base,


### PR DESCRIPTION
Can't compile Rust on Travis for a couple reasons related to [the Emscripten SDK](https://kripken.github.io/emscripten-site/docs/getting_started/downloads.html):

- The version necessary requires compiling clang from source which takes about 2 hours
- A precompiled version weighs in at about 6gb compressed, and the Travis container runs out of space when downloading/extracting it

So I'll deploy Rust manually, but Rust unit tests can still run on Travis.